### PR TITLE
Update parser.go

### DIFF
--- a/email/parser.go
+++ b/email/parser.go
@@ -56,8 +56,7 @@ func parseMessageWithHeader(headers Header, bodyReader io.Reader) (*Message, err
 	var subMessage *Message
 
 	if contentType := headers.Get("Content-Type"); len(contentType) > 0 {
-		cleanContentType := strings.Replace(contentType, " ", "", -1)
-		mediaType, mediaTypeParams, err = mime.ParseMediaType(cleanContentType)
+		mediaType, mediaTypeParams, err = mime.ParseMediaType(contentType)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes:
`{"error":"Preamble Read: bufio: buffer full","level":"error","msg":"parsing email","namespace":"smacc","objectKey":"79no403l1fa3p779cillb8q917kaeu9ejljfdi01","time":"2020-07-15T08:34:48Z"}`

I have no idea why this change was made:
https://github.com/veqryn/go-email/commit/e082299039223bfe5cea6d3e68cbbeb015d92e4c

but it messes up the boundaries in the eml file
(which sometimes contain whitespaces) - file attached
[79no403l1fa3p779cillb8q917kaeu9ejljfdi01.txt](https://github.com/smaccio/go-email/files/4925513/79no403l1fa3p779cillb8q917kaeu9ejljfdi01.txt)

e.g. `--boundary Wed, 15 Jul 2020 10:35:39 +0200 boundary--`

